### PR TITLE
Allow editing entry text from detail screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 .externalNativeBuild
 .cxx
 local.properties
+*.keystore
+*.jks

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 local.properties
 *.keystore
 *.jks
+fdroidvenv

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A privacy-focused, open-source memory crutch app for Android that lets you captu
 - 📍 **Location Tracking**: Optional GPS location for entries (using native Android LocationManager)
 - 🔍 **Search**: Find entries by text content
 - 🗂️ **Browse**: View all entries sorted by timestamp
+- ✏️ **Edit Entries**: Open an entry from Browse, tweak its text from the detail screen while keeping photo and location intact
 - 🗑️ **Delete**: Remove entries with confirmation dialog
 - 🔒 **Privacy**: All data stored locally, FOSS-compatible
 

--- a/WARP.md
+++ b/WARP.md
@@ -1,0 +1,100 @@
+# WARP.md
+
+This file provides guidance to WARP (warp.dev) when working with code in this repository.
+
+## Common Commands
+
+### Build & Install
+- Debug APK:
+  ```bash
+  ./gradlew assembleDebug
+  ```
+- Release APK (unsigned):
+  ```bash
+  ./gradlew assembleRelease
+  ```
+- Install on a connected device or emulator:
+  ```bash
+  ./gradlew installDebug
+  ```
+
+### Lint & Static Analysis
+- Run the full Android/Kotlin linter suite:
+  ```bash
+  ./gradlew lint
+  ```
+  Lint reports are written to `app/build/reports/lint-results-debug.html`.
+
+### Tests
+- JVM unit tests (pure Kotlin/Java):
+  ```bash
+  ./gradlew testDebugUnitTest
+  ```
+- Instrumented UI tests on a device/emulator:
+  ```bash
+  ./gradlew connectedDebugAndroidTest
+  ```
+- Run a single JVM unit test class or method:
+  ```bash
+  ./gradlew testDebugUnitTest --tests "com.qq7te.totalrecall.EntryRepositoryUpdateTextTest"
+  ```
+  Replace the fully-qualified name with the desired test pattern.
+
+### Dependency Updates (Version Catalog)
+If you modify `gradle/libs.versions.toml`, refresh wrappers and IDE metadata with:
+```bash
+./gradlew buildHealth
+```
+
+## High-Level Architecture
+
+The project targets Android 31–35 and is organised as a single Gradle module `:app` that follows a clean MVVM approach with Room persistence:
+
+1. **Data layer**  
+   • `entity/` – Room @Entity data classes representing a memory entry.  
+   • `dao/` – Room @Dao interfaces for database access (suspend functions).  
+   • `repository/` – Bridges DAO calls to the domain, exposed as Kotlin Flows.
+
+2. **Domain/ViewModel layer**  
+   • `viewmodel/` – AndroidX ViewModel classes that expose `LiveData` / `StateFlow` to the UI and encapsulate coroutine scopes.  
+   • Business rules such as search and export live here.
+
+3. **UI layer**  
+   • The app uses a hybrid UI: traditional Fragments + XML layouts for navigation chrome, and Jetpack Compose for isolated screens (previewable components).  
+   • Navigation is orchestrated by `androidx.navigation` with a `NavHostFragment` declared in `MainActivity`. Destinations are listed in `navigation/nav_graph.xml`.
+
+4. **Camera & Media**  
+   • `camera/` package wraps CameraX Preview + ImageCapture use cases.  
+   • Captured images are stored in the app-private media directory; paths are persisted in the DB.
+
+5. **Export & Import**  
+   • `export/` contains utilities to serialise entries to JSON via Gson.  
+   • Zipping helpers live in `utils/FileUtils.kt`.
+
+6. **Third-party libs**  
+   • CameraX, Glide, Room, Coroutines, Compose Material3.
+
+### Data Flow Summary
+```
+UI (Fragment/Compose) ─▶ ViewModel ─▶ Repository ─▶ Room DAO ─▶ SQLite
+                                              ▲
+                                              │
+                                   CameraX / File IO
+```
+User actions propagate down to Room; changes stream back up via `Flow`/`LiveData` to auto-update the UI.
+
+### Editing Existing Entries
+
+Entries can be re-edited from the detail screen:
+- `BrowseFragment` opens `DetailFragment` for a specific entry.
+- The **Edit Entry** button in `DetailFragment` navigates to `CaptureFragment` with an `entryId` argument.
+- `CaptureFragment` switches to an "edit" mode (no camera preview) that pre-fills the existing photo and text.
+- Saving in edit mode calls `EntryRepository.updateEntryText`, which delegates to `EntryDao.updateEntryText` to update only the `text` column.
+
+## Project-Specific Rules for Future Agents
+
+1. Use **suspend** DAO functions and favour `Flow` over `LiveData` in new code.  
+2. Prefer Jetpack **Compose** for any new screens; legacy XML may remain until migrated.  
+3. Avoid Google Play Services – location uses `LocationManager`, maps are out of scope.
+4. Keep the app F-Droid-compatible: no proprietary binaries or closed-source SDKs.
+

--- a/app/src/main/java/com/qq7te/totalrecall/data/EntryDao.kt
+++ b/app/src/main/java/com/qq7te/totalrecall/data/EntryDao.kt
@@ -20,6 +20,9 @@ interface EntryDao {
     @Query("SELECT * FROM entries WHERE id = :id")
     fun getEntryById(id: Long): Entry
     
+    @Query("UPDATE entries SET text = :text WHERE id = :id")
+    suspend fun updateEntryText(id: Long, text: String): Int
+    
     @Delete
     suspend fun delete(entry: Entry): Int
     

--- a/app/src/main/java/com/qq7te/totalrecall/data/EntryRepository.kt
+++ b/app/src/main/java/com/qq7te/totalrecall/data/EntryRepository.kt
@@ -24,6 +24,12 @@ class EntryRepository(private val entryDao: EntryDao) {
         }
     }
     
+    suspend fun updateEntryText(id: Long, text: String) {
+        return withContext(Dispatchers.IO) {
+            entryDao.updateEntryText(id, text)
+        }
+    }
+    
     suspend fun delete(entry: Entry) {
         return withContext(Dispatchers.IO) {
             entryDao.delete(entry)

--- a/app/src/main/java/com/qq7te/totalrecall/ui/capture/CaptureViewModel.kt
+++ b/app/src/main/java/com/qq7te/totalrecall/ui/capture/CaptureViewModel.kt
@@ -18,6 +18,18 @@ class CaptureViewModel(private val repository: EntryRepository) : ViewModel() {
         )
         repository.insert(entry)
     }
+
+    suspend fun getEntryById(id: Long): Entry? {
+        return try {
+            repository.getEntryById(id)
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    suspend fun updateEntryText(id: Long, newText: String) {
+        repository.updateEntryText(id, newText)
+    }
 }
 
 class CaptureViewModelFactory(private val repository: EntryRepository) : ViewModelProvider.Factory {

--- a/app/src/main/java/com/qq7te/totalrecall/ui/detail/DetailFragment.kt
+++ b/app/src/main/java/com/qq7te/totalrecall/ui/detail/DetailFragment.kt
@@ -86,6 +86,16 @@ class DetailFragment : Fragment() {
         binding.buttonDelete.setOnClickListener {
             showDeleteConfirmationDialog()
         }
+
+        binding.buttonEdit.setOnClickListener {
+            val action = DetailFragmentDirections.actionDetailToCapture(args.entryId)
+            findNavController().navigate(action)
+        }
+    }
+    
+    override fun onResume() {
+        super.onResume()
+        viewModel.refreshEntry()
     }
     
     private fun showDeleteConfirmationDialog() {

--- a/app/src/main/java/com/qq7te/totalrecall/ui/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/qq7te/totalrecall/ui/detail/DetailViewModel.kt
@@ -21,10 +21,10 @@ class DetailViewModel(
     val deleteResult: LiveData<Boolean?> = _deleteResult
     
     init {
-        loadEntry()
+        refreshEntry()
     }
     
-    private fun loadEntry() {
+    fun refreshEntry() {
         viewModelScope.launch {
             try {
                 _entry.value = repository.getEntryById(entryId)

--- a/app/src/main/res/layout/fragment_detail.xml
+++ b/app/src/main/res/layout/fragment_detail.xml
@@ -56,6 +56,17 @@
             tools:text="This is the content of the entry with all the details that the user entered when creating this entry." />
 
         <Button
+            android:id="@+id/button_edit"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:text="Edit Entry"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/text_content"
+            app:layout_constraintEnd_toStartOf="@+id/button_delete"
+            app:layout_constraintHorizontal_chainStyle="packed" />
+
+        <Button
             android:id="@+id/button_delete"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -63,8 +74,8 @@
             android:backgroundTint="@android:color/holo_red_dark"
             android:text="Delete Entry"
             android:textColor="@android:color/white"
+            app:layout_constraintStart_toEndOf="@+id/button_edit"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/text_content" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -9,7 +9,12 @@
         android:id="@+id/navigation_capture"
         android:name="com.qq7te.totalrecall.ui.capture.CaptureFragment"
         android:label="Capture"
-        tools:layout="@layout/fragment_capture" />
+        tools:layout="@layout/fragment_capture">
+        <argument
+            android:name="entryId"
+            app:argType="long"
+            android:defaultValue="0L" />
+    </fragment>
 
     <fragment
         android:id="@+id/navigation_browse"
@@ -29,5 +34,8 @@
         <argument
             android:name="entryId"
             app:argType="long" />
+        <action
+            android:id="@+id/action_detail_to_capture"
+            app:destination="@id/navigation_capture" />
     </fragment>
 </navigation> 

--- a/app/src/test/java/com/qq7te/totalrecall/EntryRepositoryUpdateTextTest.kt
+++ b/app/src/test/java/com/qq7te/totalrecall/EntryRepositoryUpdateTextTest.kt
@@ -1,0 +1,121 @@
+package com.qq7te.totalrecall
+
+import com.qq7te.totalrecall.data.Entry
+import com.qq7te.totalrecall.data.EntryDao
+import com.qq7te.totalrecall.data.EntryRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+import java.util.Date
+
+/**
+ * Tests for the text-only update path introduced for editing existing entries.
+ *
+ * These tests use a simple in-memory FakeEntryDao so we can verify that only the
+ * text field is changed and all other fields remain untouched.
+ */
+class EntryRepositoryUpdateTextTest {
+
+    private class FakeEntryDao : EntryDao {
+        private val entries = mutableListOf<Entry>()
+        private var nextId: Long = 1L
+
+        override suspend fun insert(entry: Entry): Long {
+            val id = if (entry.id == 0L) nextId++ else entry.id
+            val stored = entry.copy(id = id)
+            entries.removeAll { it.id == id }
+            entries.add(stored)
+            return id
+        }
+
+        override fun getAllEntriesByTimestamp(): Flow<List<Entry>> =
+            flow { emit(entries.sortedByDescending { it.timestamp }) }
+
+        override fun searchEntries(searchQuery: String): Flow<List<Entry>> =
+            flow { emit(entries.filter { it.text.contains(searchQuery) }.sortedByDescending { it.timestamp }) }
+
+        override fun getEntryById(id: Long): Entry =
+            entries.first { it.id == id }
+
+        override suspend fun updateEntryText(id: Long, text: String): Int {
+            val index = entries.indexOfFirst { it.id == id }
+            if (index == -1) return 0
+            val existing = entries[index]
+            entries[index] = existing.copy(text = text)
+            return 1
+        }
+
+        override suspend fun delete(entry: Entry): Int {
+            val removed = entries.removeIf { it.id == entry.id }
+            return if (removed) 1 else 0
+        }
+
+        override suspend fun getAllEntriesForExport(): List<Entry> =
+            entries.sortedByDescending { it.timestamp }
+
+        override suspend fun clearAllEntries() {
+            entries.clear()
+        }
+    }
+
+    @Test
+    fun `updateEntryText only changes text and keeps other fields intact`() = runBlocking {
+        val dao = FakeEntryDao()
+        val repository = EntryRepository(dao)
+
+        val originalTimestamp = Date(1_756_052_557_311L)
+        val originalEntry = Entry(
+            id = 0L,
+            text = "Original notes",
+            photoPath = "content://media/external/images/media/1000000001",
+            timestamp = originalTimestamp,
+            latitude = 42.0,
+            longitude = -71.0
+        )
+
+        val id = repository.insert(originalEntry)
+
+        val newText = "Updated wine tasting notes"
+        repository.updateEntryText(id, newText)
+
+        val updated = repository.getEntryById(id)
+
+        assertEquals("Text should be updated", newText, updated.text)
+        assertEquals("Photo path should be unchanged", originalEntry.photoPath, updated.photoPath)
+        assertEquals("Latitude should be unchanged", originalEntry.latitude, updated.latitude)
+        assertEquals("Longitude should be unchanged", originalEntry.longitude, updated.longitude)
+        assertEquals("Timestamp value should be unchanged", originalEntry.timestamp.time, updated.timestamp.time)
+        // Same instance check for timestamp to ensure we didn't accidentally create a new Date in the DAO
+        assertSame("Timestamp instance should be the same", originalTimestamp, updated.timestamp)
+    }
+
+    @Test
+    fun `updateEntryText on missing id does not modify existing entries`() = runBlocking {
+        val dao = FakeEntryDao()
+        val repository = EntryRepository(dao)
+
+        val entry = Entry(
+            id = 0L,
+            text = "Entry that should stay the same",
+            photoPath = "content://media/external/images/media/1000000002",
+            timestamp = Date(1_756_052_557_311L),
+            latitude = null,
+            longitude = null
+        )
+
+        val id = repository.insert(entry)
+
+        // Attempt to update a non-existent entry id
+        repository.updateEntryText(id + 1, "This should not be applied")
+
+        val stillOriginal = repository.getEntryById(id)
+
+        assertEquals("Text should be unchanged when updating a different id", entry.text, stillOriginal.text)
+        assertEquals("Photo path should still match", entry.photoPath, stillOriginal.photoPath)
+        assertEquals("Latitude should still match", entry.latitude, stillOriginal.latitude)
+        assertEquals("Longitude should still match", entry.longitude, stillOriginal.longitude)
+    }
+}


### PR DESCRIPTION
This PR adds support for re-editing the text of an existing entry from its detail view.\n\n**Changes**\n- Add an "Edit Entry" button next to "Delete Entry" in the detail screen.\n- Wire navigation from the detail screen to the capture screen with an `entryId` argument.\n- Reuse the capture fragment in an "edit mode" that pre-fills the existing photo and text, hides camera controls, and only updates the text field in the database.\n- Refresh the detail screen when returning from the edit flow so the updated text is shown.\n- Add a repository/DAO method to update only the `text` column for an entry.\n\nCo-Authored-By: Warp <agent@warp.dev>